### PR TITLE
Make sure we are passing the pointer of args to CapRailslessMailer

### DIFF
--- a/lib/capistrano/railsless_mailer.rb
+++ b/lib/capistrano/railsless_mailer.rb
@@ -15,9 +15,9 @@ module Capistrano
     module RailslessCapistranoMailer
       def send_notification_email(cap, config = {}, *args)
         if CapRailslessMailer.respond_to? :notification_email
-          CapRailslessMailer.notification_email(cap, config, args).deliver
+          CapRailslessMailer.notification_email(cap, config, *args).deliver
         else
-          CapRailslessMailer.deliver_notification_email(cap, config, args)
+          CapRailslessMailer.deliver_notification_email(cap, config, *args)
         end
       end
     end


### PR DESCRIPTION
Make sure we are passing the pointer of args to CapRailslessMailer. Otherwise, notifcation_email will see args as a double array so it will ignore any parameters.
